### PR TITLE
fix: script was broken because of mismatched quotes, terminating the line early

### DIFF
--- a/civitai_manager/src/utils/html_generators/browser_page.py
+++ b/civitai_manager/src/utils/html_generators/browser_page.py
@@ -139,7 +139,7 @@ def generate_global_summary(output_dir):
                 
                 filesize_section = ''
                 if model.get('file_size'):
-                    filesize_section = f'<div class="file-size">Size: {model.get('file_size', 0)/1024:.2f} MB</div>'
+                    filesize_section = f'<div class="file-size">Size: {model.get("file_size", 0)/1024:.2f} MB</div>'
                 
                 trained_words_section = ''
                 if model.get('trainedWords'):


### PR DESCRIPTION
Fixes an error that was preventing using the script at all, as it would stop as soon as it checks the model size.

original commit:
https://github.com/jeremysltn/civitai-data-manager/commit/d0cc9134292b660c4056eba4b741d6726742db42#diff-6e500393d0bf516fb713dc88e6da6641b74bde12a5bdb10d926261d5354c7492R142